### PR TITLE
Get rid of the npm "should probably be bugs['url']" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>"
 , "keywords": ["email", "sendmail", "node-email"]
 , "engines": { "node": ">= 0.1.92" }
-, "bugs": "http://github.com/aheckmann/node-email/issues"
+, "bugs": { "url": "http://github.com/aheckmann/node-email/issues" }
 , "licenses": [{ "type": "MIT", "url": "http://www.opensource.org/licenses/mit-license.php" }]
 , "main": "./index"
 , "repository": { "type": "git", "url": "git://github.com/aheckmann/node-email.git" }


### PR DESCRIPTION
Hi there! Small change to get rid of rpm warning ...
