### PR TITLE
"from" parameter is not anymore required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swo
 *.swp
+node_modules

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,0 +1,11 @@
+const Email = require('../index').Email;
+
+const msg = new Email({
+	to: 'you@example.com',
+	subject: 'Knock knock...',
+	body: 'Who\'s there?'
+});
+
+// if callback is provided, errors will be passed into it
+// else errors will be thrown
+msg.send((err) => err && console.error(err));

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ Email.prototype = {
 , get msg () {
     var msg = new Msg()
       , boundry = genBoundry()
+      , from = (this.from || exports.from)
       , to = formatAddress(this.to)
       , cc = formatAddress(this.cc)
       , bcc = formatAddress(this.bcc)
@@ -115,8 +116,8 @@ Email.prototype = {
           : '';
 
     msg.line('To: ' + to);
-    msg.line('From: '+ (this.from || exports.from));
-    msg.line('Reply-To: ' + (this.replyTo || this.from || exports.from));
+    if(from) msg.line('From: '+ from);
+    if(this.replyTo || from) msg.line('Reply-To: ' + (this.replyTo || from));
     msg.line('Subject: '+ this.subject);
 
     if (cc) msg.line('CC: ' + cc);
@@ -274,9 +275,9 @@ function fieldsAreClean (email, callback) {
  */
 
 function requiredFieldsExist (email, callback) {
-  if (!email.from && !exports.from) {
-    return error('from is required', callback);
-  }
+  // if (!email.from && !exports.from) {
+  //   return error('from is required', callback);
+  // }
 
   if (!email.to) {
     return error('to is required', callback);


### PR DESCRIPTION
Hey thank you very much for this wrapper, even it is old it is very useful. But I found the mandatory _from_ parameter a bit annoying so I removed the validator because this field is not mandatory with **sendmail** and I would like to use this package without providing the _from_ address.
